### PR TITLE
Builder.warn was deprecated

### DIFF
--- a/sphinxcontrib/seqdiag.py
+++ b/sphinxcontrib/seqdiag.py
@@ -21,6 +21,7 @@ from collections import namedtuple
 from docutils import nodes
 from sphinx import addnodes
 from sphinx.util.osutil import ensuredir
+from sphinx.util import logging
 
 import seqdiag.utils.rst.nodes
 import seqdiag.utils.rst.directives
@@ -32,6 +33,7 @@ from blockdiag.utils.rst.directives import with_blockdiag
 # fontconfig; it will be initialized on `builder-inited` event.
 fontmap = None
 
+logger = logging.getLogger(__name__)
 
 class seqdiag_node(seqdiag.utils.rst.nodes.seqdiag):
     def to_drawer(self, image_format, builder, **kwargs):
@@ -110,7 +112,7 @@ def resolve_reference(builder, href):
             else:
                 return xref['refuri']
         else:
-            builder.warn('undefined label: %s' % refid)
+            logger.warn('undefined label: %s' % refid)
             return None
 
 
@@ -212,13 +214,13 @@ def html_visit_seqdiag(self, node):
 
         msg = ("seqdiag error: UnicodeEncodeError caught "
                "(check your font settings)")
-        self.builder.warn(msg)
+        logger.warn(msg)
         raise nodes.SkipNode
     except Exception as exc:
         if self.builder.config.seqdiag_debug:
             traceback.print_exc()
 
-        self.builder.warn('dot code %r: %s' % (node['code'], str(exc)))
+        logger.warn('dot code %r: %s' % (node['code'], str(exc)))
         raise nodes.SkipNode
 
 
@@ -253,7 +255,7 @@ def get_image_format_for(builder):
 def on_builder_inited(self):
     # show deprecated message
     if self.builder.config.seqdiag_tex_image_format:
-        self.builder.warn('seqdiag_tex_image_format is deprecated. Use seqdiag_latex_image_format.')
+        logger.warn('seqdiag_tex_image_format is deprecated. Use seqdiag_latex_image_format.')
 
     # initialize fontmap
     global fontmap
@@ -287,7 +289,7 @@ def on_doctree_resolved(self, doctree, docname):
         if self.builder.config.seqdiag_debug:
             traceback.print_exc()
 
-        self.builder.warn('seqdiag error: %s' % exc)
+        logger.warn('seqdiag error: %s' % exc)
         for node in doctree.traverse(seqdiag_node):
             node.parent.remove(node)
 
@@ -308,7 +310,7 @@ def on_doctree_resolved(self, doctree, docname):
             if self.builder.config.seqdiag_debug:
                 traceback.print_exc()
 
-            self.builder.warn('dot code %r: %s' % (node['code'], str(exc)))
+            logger.warn('dot code %r: %s' % (node['code'], str(exc)))
             node.parent.remove(node)
 
 


### PR DESCRIPTION
`warn()` API was deprecated from 1.6 and removed from 2.0.

```
AttributeError: 'LaTeXBuilder' object has no attribute 'warn'
```

I replaced logger API to using `sphinx.util.logging`.