### PR TITLE
Refactor deprecated unittest aliases for Python 3.11 compatibility.

### DIFF
--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -29,7 +29,7 @@ class TestSphinxcontribSeqdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, r'<div><img .*? src="_images/.*?.png" .*?/></div>')
+        self.assertRegex(source, r'<div><img .*? src="_images/.*?.png" .*?/></div>')
 
     @with_app(srcdir='tests/docs/subdir', buildername='html', write_docstring=True)
     def test_build_png_image_in_subdir(self, app, status, warning):
@@ -40,7 +40,7 @@ class TestSphinxcontribSeqdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'subdir' / 'index.html').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, r'<div><img .*? src="\.\./_images/.*?.png" .*?/></div>')
+        self.assertRegex(source, r'<div><img .*? src="\.\./_images/.*?.png" .*?/></div>')
 
     @with_png_app
     def test_width_option_on_png(self, app, status, warning):
@@ -52,8 +52,8 @@ class TestSphinxcontribSeqdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, (r'<div><a class="reference internal image-reference" href="(.*?.png)">'
-                                          r'<img height="97.0" src="\1" width="224.0" /></a></div>'))
+        self.assertRegex(source, (r'<div><a class="reference internal image-reference" href="(.*?.png)">'
+                                  r'<img height="97.0" src="\1" width="224.0" /></a></div>'))
 
     @with_png_app
     def test_height_option_on_png(self, app, status, warning):
@@ -65,8 +65,8 @@ class TestSphinxcontribSeqdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, (r'<div><a class="reference internal image-reference" href="(.*?.png)">'
-                                          r'<img height="97.0" src="\1" width="224.0" /></a></div>'))
+        self.assertRegex(source, (r'<div><a class="reference internal image-reference" href="(.*?.png)">'
+                                  r'<img height="97.0" src="\1" width="224.0" /></a></div>'))
 
     @with_png_app
     def test_width_option_and_height_option_on_png(self, app, status, warning):
@@ -79,8 +79,8 @@ class TestSphinxcontribSeqdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, (r'<div><a class="reference internal image-reference" href="(.*?.png)">'
-                                          r'<img height="200.0" src="\1" width="100.0" /></a></div>'))
+        self.assertRegex(source, (r'<div><a class="reference internal image-reference" href="(.*?.png)">'
+                                  r'<img height="200.0" src="\1" width="100.0" /></a></div>'))
 
     @with_png_app
     def test_scale_option_on_png(self, app, status, warning):
@@ -92,8 +92,8 @@ class TestSphinxcontribSeqdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, (r'<div><a class="reference internal image-reference" href="(.*?.png)">'
-                                          r'<img height="48.5" src="\1" width="112.0" /></a></div>'))
+        self.assertRegex(source, (r'<div><a class="reference internal image-reference" href="(.*?.png)">'
+                                  r'<img height="48.5" src="\1" width="112.0" /></a></div>'))
 
     @with_png_app
     def test_width_option_and_scale_option_on_png(self, app, status, warning):
@@ -106,8 +106,8 @@ class TestSphinxcontribSeqdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, (r'<div><a class="reference internal image-reference" href="(.*?.png)">'
-                                          r'<img height="3.03125" src="\1" width="7.0" /></a></div>'))
+        self.assertRegex(source, (r'<div><a class="reference internal image-reference" href="(.*?.png)">'
+                                  r'<img height="3.03125" src="\1" width="7.0" /></a></div>'))
 
     @with_png_app
     def test_align_option_on_png(self, app, status, warning):
@@ -119,7 +119,7 @@ class TestSphinxcontribSeqdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, r'<div align="center" class="align-center"><img .*? /></div>')
+        self.assertRegex(source, r'<div align="center" class="align-center"><img .*? /></div>')
 
     @with_png_app
     def test_align_option_and_width_option_on_png(self, app, status, warning):
@@ -132,9 +132,9 @@ class TestSphinxcontribSeqdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, (r'<div align="center" class="align-center">'
-                                          r'<a class="reference internal image-reference" href="(.*?.png)">'
-                                          r'<img height="97.0" src="\1" width="224.0" /></a></div>'))
+        self.assertRegex(source, (r'<div align="center" class="align-center">'
+                                  r'<a class="reference internal image-reference" href="(.*?.png)">'
+                                  r'<img height="97.0" src="\1" width="224.0" /></a></div>'))
 
     @with_png_app
     def test_name_option_on_png(self, app, status, warning):
@@ -146,7 +146,7 @@ class TestSphinxcontribSeqdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, r'<div><img .*? id="target" src=".*?" .*? /></div>')
+        self.assertRegex(source, r'<div><img .*? id="target" src=".*?" .*? /></div>')
 
     @with_png_app
     def test_name_option_and_width_option_on_png(self, app, status, warning):
@@ -159,8 +159,8 @@ class TestSphinxcontribSeqdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, (r'<div><a class="reference internal image-reference" href="(.*?.png)">'
-                                          r'<img height="97.0" id="target" src="\1" width="224.0" /></a></div>'))
+        self.assertRegex(source, (r'<div><a class="reference internal image-reference" href="(.*?.png)">'
+                                  r'<img height="97.0" id="target" src="\1" width="224.0" /></a></div>'))
 
     @with_png_app
     def test_href_and_scale_option_on_png(self, app, status, warning):
@@ -173,11 +173,11 @@ class TestSphinxcontribSeqdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, (r'<div><a class="reference internal image-reference" href="(.*?.png)">'
-                                          r'<map name="(map_\d+)">'
-                                          r'<area shape="rect" coords="32.0,20.0,96.0,40.0" '
-                                          r'href="http://blockdiag.com/"></map>'
-                                          r'<img .*? src="\1" usemap="#\2" .*?/></a></div>'))
+        self.assertRegex(source, (r'<div><a class="reference internal image-reference" href="(.*?.png)">'
+                                  r'<map name="(map_\d+)">'
+                                  r'<area shape="rect" coords="32.0,20.0,96.0,40.0" '
+                                  r'href="http://blockdiag.com/"></map>'
+                                  r'<img .*? src="\1" usemap="#\2" .*?/></a></div>'))
 
     @with_png_app
     def test_reftarget_in_href_on_png1(self, app, status, warning):
@@ -194,9 +194,9 @@ class TestSphinxcontribSeqdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, (r'<div><map name="(map_\d+)">'
-                                          r'<area shape="rect" coords="64.0,40.0,192.0,80.0" href="#target"></map>'
-                                          r'<img .*? src=".*?.png" usemap="#\1" .*?/></div>'))
+        self.assertRegex(source, (r'<div><map name="(map_\d+)">'
+                                  r'<area shape="rect" coords="64.0,40.0,192.0,80.0" href="#target"></map>'
+                                  r'<img .*? src=".*?.png" usemap="#\1" .*?/></div>'))
 
     @with_png_app
     def test_reftarget_in_href_on_png2(self, app, status, warning):
@@ -213,9 +213,9 @@ class TestSphinxcontribSeqdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, (r'<div><map name="(map_\d+)">'
-                                          r'<area shape="rect" coords="64.0,40.0,192.0,80.0" href="#hello-world">'
-                                          r'</map><img .*? src=".*?.png" usemap="#\1" .*?/></div>'))
+        self.assertRegex(source, (r'<div><map name="(map_\d+)">'
+                                  r'<area shape="rect" coords="64.0,40.0,192.0,80.0" href="#hello-world">'
+                                  r'</map><img .*? src=".*?.png" usemap="#\1" .*?/></div>'))
 
     @with_png_app
     def test_missing_reftarget_in_href_on_png(self, app, status, warning):
@@ -227,7 +227,7 @@ class TestSphinxcontribSeqdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, (r'<div><img .*? src=".*?.png" .*?/></div>'))
+        self.assertRegex(source, (r'<div><img .*? src=".*?.png" .*?/></div>'))
         self.assertIn('undefined label: unknown_target', warning.getvalue())
 
     @with_svg_app
@@ -239,7 +239,7 @@ class TestSphinxcontribSeqdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, r'<div><svg .*?>')
+        self.assertRegex(source, r'<div><svg .*?>')
 
     @with_svg_app
     def test_width_option_on_svg(self, app, status, warning):
@@ -251,7 +251,7 @@ class TestSphinxcontribSeqdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, r'<div><svg height="97.0" viewBox="0 0 448 194" width="224.0" .*?>')
+        self.assertRegex(source, r'<div><svg height="97.0" viewBox="0 0 448 194" width="224.0" .*?>')
 
     @with_svg_app
     def test_height_option_on_svg(self, app, status, warning):
@@ -263,7 +263,7 @@ class TestSphinxcontribSeqdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, r'<div><svg height="97.0" viewBox="0 0 448 194" width="224.0" .*?>')
+        self.assertRegex(source, r'<div><svg height="97.0" viewBox="0 0 448 194" width="224.0" .*?>')
 
     @with_svg_app
     def test_width_option_and_height_option_on_svg(self, app, status, warning):
@@ -276,7 +276,7 @@ class TestSphinxcontribSeqdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, r'<div><svg height="200.0" viewBox="0 0 448 194" width="100.0" .*?>')
+        self.assertRegex(source, r'<div><svg height="200.0" viewBox="0 0 448 194" width="100.0" .*?>')
 
     @with_svg_app
     def test_scale_option_on_svg(self, app, status, warning):
@@ -288,7 +288,7 @@ class TestSphinxcontribSeqdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, r'<div><svg height="48.5" viewBox="0 0 448 194" width="112.0" .*?>')
+        self.assertRegex(source, r'<div><svg height="48.5" viewBox="0 0 448 194" width="112.0" .*?>')
 
     @with_svg_app
     def test_width_option_and_scale_option_on_svg(self, app, status, warning):
@@ -301,7 +301,7 @@ class TestSphinxcontribSeqdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, r'<div><svg height="3.03125" viewBox="0 0 448 194" width="7.0" .*?>')
+        self.assertRegex(source, r'<div><svg height="3.03125" viewBox="0 0 448 194" width="7.0" .*?>')
 
     @with_svg_app
     def test_align_option_on_svg(self, app, status, warning):
@@ -313,7 +313,7 @@ class TestSphinxcontribSeqdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, r'<div align="center" class="align-center"><svg .*?>')
+        self.assertRegex(source, r'<div align="center" class="align-center"><svg .*?>')
 
     @with_svg_app
     def test_name_option_on_svg(self, app, status, warning):
@@ -325,7 +325,7 @@ class TestSphinxcontribSeqdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, r'<div><span id="target"></span><svg .*?>')
+        self.assertRegex(source, r'<div><span id="target"></span><svg .*?>')
 
     @with_svg_app
     def test_reftarget_in_href_on_svg1(self, app, status, warning):
@@ -342,7 +342,7 @@ class TestSphinxcontribSeqdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, r'<a xlink:href="#target">\n\s*<rect .*?>\n\s*</a>')
+        self.assertRegex(source, r'<a xlink:href="#target">\n\s*<rect .*?>\n\s*</a>')
 
     @with_svg_app
     def test_reftarget_in_href_on_svg2(self, app, status, warning):
@@ -359,7 +359,7 @@ class TestSphinxcontribSeqdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, r'<a xlink:href="#hello-world">\n\s*<rect .*?>\n\s*</a>')
+        self.assertRegex(source, r'<a xlink:href="#hello-world">\n\s*<rect .*?>\n\s*</a>')
 
     @with_svg_app
     def test_missing_reftarget_in_href_on_svg(self, app, status, warning):
@@ -371,10 +371,7 @@ class TestSphinxcontribSeqdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
-        if sys.version_info < (3, 0):
-            self.assertNotRegexpMatches(source, r'<a xlink:href="#hello-world">\n\s*<rect .*?>\n\s*</a>')
-        else:
-            self.assertNotRegex(source, r'<a xlink:href="#hello-world">\n\s*<rect .*?>\n\s*</a>')
+        self.assertNotRegex(source, r'<a xlink:href="#hello-world">\n\s*<rect .*?>\n\s*</a>')
         self.assertIn('undefined label: unknown_target', warning.getvalue())
 
     @with_svg_app
@@ -395,4 +392,4 @@ class TestSphinxcontribSeqdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, r'<text[^>]+>A_foo</text>')  # 2nd diagram has a node labeled 'A_foo'.
+        self.assertRegex(source, r'<text[^>]+>A_foo</text>')  # 2nd diagram has a node labeled 'A_foo'.

--- a/tests/test_latex.py
+++ b/tests/test_latex.py
@@ -43,7 +43,7 @@ class TestSphinxcontribSeqdiagLatex(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'test.tex').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, r'\\sphinxincludegraphics{{seqdiag-.*?}.png}')
+        self.assertRegex(source, r'\\sphinxincludegraphics{{seqdiag-.*?}.png}')
 
     @unittest.skipUnless(os.path.exists(seqdiag_fontpath), "TrueType font not found")
     @with_pdf_app
@@ -55,7 +55,7 @@ class TestSphinxcontribSeqdiagLatex(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'test.tex').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, r'\\sphinxincludegraphics{seqdiag-.*?.pdf}')
+        self.assertRegex(source, r'\\sphinxincludegraphics{seqdiag-.*?.pdf}')
 
     @unittest.skipUnless(os.path.exists(seqdiag_fontpath), "TrueType font not found")
     @with_oldpdf_app
@@ -67,7 +67,7 @@ class TestSphinxcontribSeqdiagLatex(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'test.tex').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, r'\\sphinxincludegraphics{{seqdiag-.*?}.pdf}')
+        self.assertRegex(source, r'\\sphinxincludegraphics{{seqdiag-.*?}.pdf}')
 
     @with_png_app
     def test_width_option(self, app, status, warning):
@@ -79,7 +79,7 @@ class TestSphinxcontribSeqdiagLatex(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'test.tex').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, r'\\sphinxincludegraphics\[width=3cm\]{{seqdiag-.*?}.png}')
+        self.assertRegex(source, r'\\sphinxincludegraphics\[width=3cm\]{{seqdiag-.*?}.png}')
 
     @with_png_app
     def test_height_option(self, app, status, warning):
@@ -91,7 +91,7 @@ class TestSphinxcontribSeqdiagLatex(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'test.tex').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, r'\\sphinxincludegraphics\[height=4cm\]{{seqdiag-.*?}.png}')
+        self.assertRegex(source, r'\\sphinxincludegraphics\[height=4cm\]{{seqdiag-.*?}.png}')
 
     @with_png_app
     def test_scale_option(self, app, status, warning):
@@ -103,7 +103,7 @@ class TestSphinxcontribSeqdiagLatex(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'test.tex').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, r'\\sphinxincludegraphics\[scale=0.5\]{{seqdiag-.*?}.png}')
+        self.assertRegex(source, r'\\sphinxincludegraphics\[scale=0.5\]{{seqdiag-.*?}.png}')
 
     @with_png_app
     def test_align_option_left(self, app, status, warning):
@@ -115,8 +115,8 @@ class TestSphinxcontribSeqdiagLatex(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'test.tex').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, (r'{\\sphinxincludegraphics{{seqdiag-.*?}.png}'
-                                          r'\\hspace\*{\\fill}}'))
+        self.assertRegex(source, (r'{\\sphinxincludegraphics{{seqdiag-.*?}.png}'
+                                  r'\\hspace\*{\\fill}}'))
 
     @with_png_app
     def test_align_option_center(self, app, status, warning):
@@ -128,9 +128,9 @@ class TestSphinxcontribSeqdiagLatex(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'test.tex').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, (r'{\\hspace\*{\\fill}'
-                                          r'\\sphinxincludegraphics{{seqdiag-.*?}.png}'
-                                          r'\\hspace\*{\\fill}}'))
+        self.assertRegex(source, (r'{\\hspace\*{\\fill}'
+                                  r'\\sphinxincludegraphics{{seqdiag-.*?}.png}'
+                                  r'\\hspace\*{\\fill}}'))
 
     @with_png_app
     def test_align_option_right(self, app, status, warning):
@@ -142,8 +142,8 @@ class TestSphinxcontribSeqdiagLatex(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'test.tex').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, (r'{\\hspace\*{\\fill}'
-                                          r'\\sphinxincludegraphics{{seqdiag-.*?}.png}}'))
+        self.assertRegex(source, (r'{\\hspace\*{\\fill}'
+                                  r'\\sphinxincludegraphics{{seqdiag-.*?}.png}}'))
 
     @with_png_app
     def test_caption_option(self, app, status, warning):
@@ -162,7 +162,7 @@ class TestSphinxcontribSeqdiagLatex(unittest.TestCase):
                              r'\\noindent\\sphinxincludegraphics{{seqdiag-.*?}.png}' + CR +
                              r'\\caption{hello world}\\label{\\detokenize{index:id1}}\\end{figure}'),
                             re.DOTALL)
-        self.assertRegexpMatches(source, figure)
+        self.assertRegex(source, figure)
 
     @with_png_app
     def test_caption_option_and_align_option(self, app, status, warning):
@@ -181,7 +181,7 @@ class TestSphinxcontribSeqdiagLatex(unittest.TestCase):
                              r'\\noindent\\sphinxincludegraphics{{seqdiag-.*?}.png}' + CR +
                              r'\\caption{hello world}\\label{\\detokenize{index:id1}}\\end{wrapfigure}'),
                             re.DOTALL)
-        self.assertRegexpMatches(source, figure)
+        self.assertRegex(source, figure)
 
     @with_png_app
     def test_href(self, app, status, warning):
@@ -193,4 +193,4 @@ class TestSphinxcontribSeqdiagLatex(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'test.tex').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, r'\\sphinxincludegraphics{{seqdiag-.*?}.png}')
+        self.assertRegex(source, r'\\sphinxincludegraphics{{seqdiag-.*?}.png}')


### PR DESCRIPTION
The deprecated aliases were removed in https://github.com/python/cpython/pull/28268